### PR TITLE
add Stories and ShortDescription to schemas

### DIFF
--- a/catalog/collection-schema.json
+++ b/catalog/collection-schema.json
@@ -84,6 +84,13 @@
             },
             "description": "List of <b>providers</b> of the collection"
         },
+        "Stories": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/Story"
+            },
+            "description": "List of stories where the collection is used."
+        },
         "Citation": {
             "$ref": "#/$defs/Citation",
             "description": "Citation object containing information on citation aspects of data"
@@ -129,13 +136,13 @@
             "$ref": "#/$defs/Process",
             "description": "Configuration of the process of the collection"
         },
-        "EodashIdentifier": {
-            "type": "string",
-            "description": "Identifier that will be used within the eodash client"
-        },
         "Subtitle": {
             "type": "string",
             "description": "Optional short description"
+        },
+        "ShortDescription": {
+            "type": "string",
+            "description": "Optional shorter description than description. Can not use markdown."
         }
     },
     "required": [
@@ -333,6 +340,22 @@
             },
             "required": [
                 "Name",
+                "Url"
+            ]
+        },
+        "Story": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "type": "string",
+                    "description": "The title of the Story. If not provided, filename is used as a fallback."
+                },
+                "Url": {
+                    "type": "string",
+                    "description": "URL to the story. Can be provided as relative path (which root is taken from the stories_endpoint configured for the catalog) to a story markdown file or an absolute URL to either the rendered story or to the raw markdown."
+                }
+            },
+            "required": [
                 "Url"
             ]
         },

--- a/catalog/eodashboard-collection-schema.json
+++ b/catalog/eodashboard-collection-schema.json
@@ -90,6 +90,13 @@
             },
             "description": "List of <b>providers</b> of the collection"
         },
+        "Stories": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/Story"
+            },
+            "description": "List of <b>stories</b> where the collection is used."
+        },
         "Citation": {
             "$ref": "#/$defs/Citation",
             "description": "Citation object containing information on citation aspects of data"
@@ -136,6 +143,10 @@
             "description": "Configuration of the process of the collection"
         },
         "Subtitle": {
+            "type": "string",
+            "description": "Optional short description"
+        },
+        "ShortDescription": {
             "type": "string",
             "description": "Optional short description"
         }
@@ -336,6 +347,22 @@
             },
             "required": [
                 "Name",
+                "Url"
+            ]
+        },
+        "Story": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "type": "string",
+                    "description": "The title of the Story. If not provided, filename is used as a fallback."
+                },
+                "Url": {
+                    "type": "string",
+                    "description": "URL to the story. Can be provided as relative path (which root is taken from the stories_endpoint configured for the catalog) to a story markdown file or an absolute URL to either the rendered story or to the raw markdown."
+                }
+            },
+            "required": [
                 "Url"
             ]
         },


### PR DESCRIPTION
- ShortDescription is needed for RACE pages 
- Stories can be used overall in all dashboards to signal link of collection to story url (ideally the rendered one) (entries will get stored as assets)
already added to wiki