### PR TITLE
feat: remove eodashidentifier

### DIFF
--- a/catalog/eodashboard-collection-schema.json
+++ b/catalog/eodashboard-collection-schema.json
@@ -11,12 +11,6 @@
         {
             "type": "object",
             "properties": {
-                "EodashIdentifier": {
-                    "type": "string",
-                    "minLength": 1,
-                    "pattern": "^[a-zA-Z0-9_-]+$",
-                    "description": "Identifier that will be used in eodashboard or RACE instance"
-                },
                 "Resources": {
                     "maxItems": 1,
                     "type": "array",


### PR DESCRIPTION
Removes concept of EodashIdentifier from eodashboard catalog schema

keeping the schema itself for now because of different collection types used - those can get removed once the migration to eoapi is finished